### PR TITLE
feat: examples for flat configs and type information

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -552,6 +552,15 @@
         "@types/json-schema": "*"
       }
     },
+    "node_modules/@types/eslint__js": {
+      "version": "8.42.3",
+      "resolved": "https://registry.npmjs.org/@types/eslint__js/-/eslint__js-8.42.3.tgz",
+      "integrity": "sha512-alfG737uhmPdnvkrLdZLcEKJ/B8s9Y4hrZ+YAdzUeoArBlSUERA2E87ROfOaS4jd/C45fzOoZzidLc1IPwLqOw==",
+      "dev": true,
+      "dependencies": {
+        "@types/eslint": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
@@ -1198,6 +1207,22 @@
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
       }
+    },
+    "node_modules/flat-config-disable-type-checked": {
+      "resolved": "packages/flat-config-disable-type-checked",
+      "link": true
+    },
+    "node_modules/flat-config-typed": {
+      "resolved": "packages/flat-config-typed",
+      "link": true
+    },
+    "node_modules/flat-config-typed-tsconfig": {
+      "resolved": "packages/flat-config-typed-tsconfig",
+      "link": true
+    },
+    "node_modules/flat-config-untyped": {
+      "resolved": "packages/flat-config-untyped",
+      "link": true
     },
     "node_modules/flatted": {
       "version": "3.2.9",
@@ -1897,6 +1922,12 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/typescript-eslint": {
+      "version": "0.0.1-alpha.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-0.0.1-alpha.0.tgz",
+      "integrity": "sha512-1hNKM37dAWML/2ltRXupOq2uqcdRQyDFphl+341NTPXFLLLiDhErXx8VtaSLh3xP7SyHZdcCgpt9boYYVb3fQg==",
+      "dev": true
+    },
     "node_modules/typescript-estree-standalone": {
       "resolved": "packages/typescript-estree-standalone",
       "link": true
@@ -1948,6 +1979,43 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/flat-config-disable-type-checked": {
+      "version": "0.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "eslint": "^8.56.0",
+        "typescript": "^5.3.3",
+        "typescript-eslint": "*"
+      }
+    },
+    "packages/flat-config-typed": {
+      "version": "0.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "eslint": "^8.56.0",
+        "typescript": "^5.3.3",
+        "typescript-eslint": "*"
+      }
+    },
+    "packages/flat-config-typed-tsconfig": {
+      "version": "0.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/eslint__js": "^8.42.3",
+        "eslint": "^8.56.0",
+        "typescript": "^5.3.3",
+        "typescript-eslint": "*"
+      }
+    },
+    "packages/flat-config-untyped": {
+      "version": "0.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "eslint": "^8.56.0",
+        "typescript": "^5.3.3",
+        "typescript-eslint": "*"
       }
     },
     "packages/typed-rule-via-linter": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "description": "Various examples of working with typescript-eslint. 📝",
   "main": "index.js",
-  "repository": "https://github.com/typescript-eslint/typescript-eslint-examples",
+  "repository": "typescript-eslint/typescript-eslint-examples",
   "author": "Josh Goldberg <git@joshuakgoldberg.com>",
   "license": "MIT",
   "workspaces": [

--- a/packages/flat-config-disable-type-checked/README.md
+++ b/packages/flat-config-disable-type-checked/README.md
@@ -1,0 +1,27 @@
+# Example: Flat Config and disable-type-checked
+
+An example of using the [`typescript-eslint`](https://typescript-eslint.io/packages/typescript-eslint) package to lint TypeScript code with type information.
+
+## Setup
+
+```shell
+npm i
+```
+
+## Usage
+
+```shell
+npm run lint
+```
+
+```plaintext
+> flat-config-untyped@0.0.0 lint
+> eslint .
+
+
+~/typescript-eslint-examples/packages/flat-config-disable-type-checked/eslint.config.js
+  6:7  error  'unused' is assigned a value but never used  @typescript-eslint/no-unused-vars
+
+~/typescript-eslint-examples/packages/flat-config-disable-type-checked/src/index.ts
+  8:5  error  Unexpected `await` of a non-Promise (non-"Thenable") value  @typescript-eslint/await-thenable
+```

--- a/packages/flat-config-disable-type-checked/eslint.config.js
+++ b/packages/flat-config-disable-type-checked/eslint.config.js
@@ -1,0 +1,22 @@
+// @ts-check
+
+import eslint from "@eslint/js";
+import tseslint from "typescript-eslint";
+
+const unused = true;
+
+export default tseslint.config(
+  eslint.configs.recommended,
+  ...tseslint.configs.recommendedTypeChecked,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: true,
+      },
+    },
+  },
+  {
+    files: ["*.js"],
+    ...tseslint.configs.disableTypeChecked,
+  }
+);

--- a/packages/flat-config-disable-type-checked/package.json
+++ b/packages/flat-config-disable-type-checked/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "flat-config-disable-type-checked",
+  "version": "0.0.0",
+  "description": "Example of using `typescript-eslint` with ESLint's flat config and type information, with disable-type-checked for .js files.",
+  "main": "index.ts",
+  "repository": {
+    "directory": "packages/flat-config-disable-type-checked",
+    "type": "git",
+    "url": "https://github.com/typescript-eslint/typescript-eslint-examples"
+  },
+  "license": "MIT",
+  "devDependencies": {
+    "typescript-eslint": "*",
+    "typescript": "^5.3.3",
+    "eslint": "^8.56.0"
+  },
+  "scripts": {
+    "lint": "eslint ."
+  },
+  "type": "module"
+}

--- a/packages/flat-config-disable-type-checked/src/index.ts
+++ b/packages/flat-config-disable-type-checked/src/index.ts
@@ -1,0 +1,10 @@
+export interface GreetOptions {
+  message: string;
+  times: number;
+}
+
+export async function greet({ message, times }: GreetOptions) {
+  for (let i = 0; i < times; i += 1) {
+    await console.log(message);
+  }
+}

--- a/packages/flat-config-disable-type-checked/tsconfig.json
+++ b/packages/flat-config-disable-type-checked/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true
+  },
+  "include": ["src"]
+}

--- a/packages/flat-config-typed-tsconfig/README.md
+++ b/packages/flat-config-typed-tsconfig/README.md
@@ -1,0 +1,27 @@
+# Example: Flat Config Typed with a TSConfig
+
+An example of using the [`typescript-eslint`](https://typescript-eslint.io/packages/typescript-eslint) package to lint TypeScript code with type information and a `tsconfig.eslint.json`.
+
+## Setup
+
+```shell
+npm i
+```
+
+## Usage
+
+```shell
+npm run lint
+```
+
+```plaintext
+> flat-config-typed@0.0.0 lint
+> eslint .
+
+
+~/typescript-eslint-examples/packages/flat-config-typed-tsconfig/eslint.config.js
+  6:8  error  Async function 'unecessarilyAsync' has no 'await' expression  @typescript-eslint/require-await
+
+~/typescript-eslint-examples/packages/flat-config-typed-tsconfig/src/index.ts
+  8:5  error  Unexpected `await` of a non-Promise (non-"Thenable") value  @typescript-eslint/await-thenable
+```

--- a/packages/flat-config-typed-tsconfig/eslint.config.js
+++ b/packages/flat-config-typed-tsconfig/eslint.config.js
@@ -1,0 +1,20 @@
+// @ts-check
+
+import eslint from "@eslint/js";
+import tseslint from "typescript-eslint";
+
+export async function unecessarilyAsync() {
+  return true;
+}
+
+export default tseslint.config(
+  eslint.configs.recommended,
+  ...tseslint.configs.recommendedTypeChecked,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: "tsconfig.eslint.json",
+      },
+    },
+  }
+);

--- a/packages/flat-config-typed-tsconfig/package.json
+++ b/packages/flat-config-typed-tsconfig/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "flat-config-typed-tsconfig",
+  "version": "0.0.0",
+  "description": "Example of using `typescript-eslint` with ESLint's flat config, type information, and a `tsconfig.eslint.json`.",
+  "main": "index.ts",
+  "repository": {
+    "directory": "packages/flat-config-typed-tsconfig",
+    "type": "git",
+    "url": "https://github.com/typescript-eslint/typescript-eslint-examples"
+  },
+  "license": "MIT",
+  "devDependencies": {
+    "@types/eslint__js": "^8.42.3",
+    "eslint": "^8.56.0",
+    "typescript": "^5.3.3",
+    "typescript-eslint": "*"
+  },
+  "scripts": {
+    "lint": "eslint ."
+  },
+  "type": "module"
+}

--- a/packages/flat-config-typed-tsconfig/src/index.ts
+++ b/packages/flat-config-typed-tsconfig/src/index.ts
@@ -1,0 +1,10 @@
+export interface GreetOptions {
+  message: string;
+  times: number;
+}
+
+export async function greet({ message, times }: GreetOptions) {
+  for (let i = 0; i < times; i += 1) {
+    await console.log(message);
+  }
+}

--- a/packages/flat-config-typed-tsconfig/tsconfig.eslint.json
+++ b/packages/flat-config-typed-tsconfig/tsconfig.eslint.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "noEmit": true
+  },
+  "include": ["."]
+}

--- a/packages/flat-config-typed-tsconfig/tsconfig.json
+++ b/packages/flat-config-typed-tsconfig/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true
+  },
+  "include": ["src"]
+}

--- a/packages/flat-config-typed/README.md
+++ b/packages/flat-config-typed/README.md
@@ -1,0 +1,24 @@
+# Example: Flat Config (Typed)
+
+An example of using the [`typescript-eslint`](https://typescript-eslint.io/packages/typescript-eslint) package to lint TypeScript code with type information.
+
+## Setup
+
+```shell
+npm i
+```
+
+## Usage
+
+```shell
+npm run lint
+```
+
+```plaintext
+> flat-config-typed@0.0.0 lint
+> eslint src
+
+
+~/typescript-eslint-examples/packages/flat-config-typed/src/index.ts
+  8:5  error  Unexpected `await` of a non-Promise (non-"Thenable") value  @typescript-eslint/await-thenable
+```

--- a/packages/flat-config-typed/eslint.config.js
+++ b/packages/flat-config-typed/eslint.config.js
@@ -1,0 +1,16 @@
+// @ts-check
+
+import eslint from "@eslint/js";
+import tseslint from "typescript-eslint";
+
+export default tseslint.config(
+  eslint.configs.recommended,
+  ...tseslint.configs.recommendedTypeChecked,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: true,
+      },
+    },
+  }
+);

--- a/packages/flat-config-typed/package.json
+++ b/packages/flat-config-typed/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "flat-config-typed",
+  "version": "0.0.0",
+  "description": "Example of using `typescript-eslint` with ESLint's flat config and type information.",
+  "main": "index.ts",
+  "repository": {
+    "directory": "packages/flat-config-typed",
+    "type": "git",
+    "url": "https://github.com/typescript-eslint/typescript-eslint-examples"
+  },
+  "license": "MIT",
+  "devDependencies": {
+    "typescript-eslint": "*",
+    "typescript": "^5.3.3",
+    "eslint": "^8.56.0"
+  },
+  "scripts": {
+    "lint": "eslint src"
+  },
+  "type": "module"
+}

--- a/packages/flat-config-typed/src/index.ts
+++ b/packages/flat-config-typed/src/index.ts
@@ -1,0 +1,10 @@
+export interface GreetOptions {
+  message: string;
+  times: number;
+}
+
+export async function greet({ message, times }: GreetOptions) {
+  for (let i = 0; i < times; i += 1) {
+    await console.log(message);
+  }
+}

--- a/packages/flat-config-typed/tsconfig.json
+++ b/packages/flat-config-typed/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true
+  },
+  "include": ["src"]
+}

--- a/packages/flat-config-untyped/README.md
+++ b/packages/flat-config-untyped/README.md
@@ -1,0 +1,28 @@
+# Example: Flat Config (Untyped)
+
+An example of using the [`typescript-eslint`](https://typescript-eslint.io/packages/typescript-eslint) package to lint TypeScript code.
+This does not use type information.
+
+## Setup
+
+```shell
+npm i
+```
+
+## Usage
+
+```shell
+npm run lint
+```
+
+```plaintext
+> flat-config-untyped@0.0.0 lint
+> eslint src
+
+
+~/typescript-eslint-examples/packages/flat-config-untyped/src/index.ts
+  7:8  error  Unexpected var, use let or const instead  no-var
+
+✖ 1 problem (1 error, 0 warnings)
+  1 error and 0 warnings potentially fixable with the `--fix` option.
+```

--- a/packages/flat-config-untyped/eslint.config.js
+++ b/packages/flat-config-untyped/eslint.config.js
@@ -1,0 +1,9 @@
+// @ts-check
+
+import eslint from "@eslint/js";
+import tseslint from "typescript-eslint";
+
+export default tseslint.config(
+  eslint.configs.recommended,
+  ...tseslint.configs.recommended
+);

--- a/packages/flat-config-untyped/package.json
+++ b/packages/flat-config-untyped/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "flat-config-untyped",
+  "version": "0.0.0",
+  "description": "Example of using `typescript-eslint` with ESLint's flat config and no type information.",
+  "main": "index.ts",
+  "repository": {
+    "directory": "packages/flat-config-untyped",
+    "type": "git",
+    "url": "https://github.com/typescript-eslint/typescript-eslint-examples"
+  },
+  "license": "MIT",
+  "devDependencies": {
+    "typescript-eslint": "*",
+    "typescript": "^5.3.3",
+    "eslint": "^8.56.0"
+  },
+  "scripts": {
+    "lint": "eslint src"
+  },
+  "type": "module"
+}

--- a/packages/flat-config-untyped/src/index.ts
+++ b/packages/flat-config-untyped/src/index.ts
@@ -1,0 +1,10 @@
+export interface GreetOptions {
+  message: string;
+  times: number;
+}
+
+export function greet({ message, times }: GreetOptions) {
+  for (var i = 0; i < times; i += 1) {
+    console.log(message);
+  }
+}

--- a/packages/flat-config-untyped/tsconfig.json
+++ b/packages/flat-config-untyped/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true
+  },
+  "include": ["src"]
+}

--- a/packages/typed-rule-via-linter/package.json
+++ b/packages/typed-rule-via-linter/package.json
@@ -3,7 +3,11 @@
   "version": "0.0.0",
   "description": "Example of using `@typescript-eslint/typescript-estree` with type information on its own.",
   "main": "index.ts",
-  "repository": "https://github.com/typescript-eslint/typescript-eslint-examples",
+  "repository": {
+    "directory": "packages/typed-rule-via-linter",
+    "type": "git",
+    "url": "https://github.com/typescript-eslint/typescript-eslint-examples"
+  },
   "license": "MIT",
   "dependencies": {
     "@typescript-eslint/parser": "^6.19.1",

--- a/packages/typescript-estree-standalone/package.json
+++ b/packages/typescript-estree-standalone/package.json
@@ -3,7 +3,11 @@
   "version": "0.0.0",
   "description": "Example of using `@typescript-eslint/typescript-estree` with type information on its own.",
   "main": "index.ts",
-  "repository": "https://github.com/typescript-eslint/typescript-eslint-examples",
+  "repository": {
+    "directory": "packages/typescript-estree-standalone",
+    "type": "git",
+    "url": "https://github.com/typescript-eslint/typescript-eslint-examples"
+  },
   "license": "MIT",
   "dependencies": {
     "@typescript-eslint/typescript-estree": "^6.19.1",


### PR DESCRIPTION
Fixes #3.

Also cleans up the `repository` field in `package.json` files.

Note that until v7 is released in two days, the `typescript-eslint` package needs to be symlinked locally.